### PR TITLE
Excluded connectivity

### DIFF
--- a/morfeus/cone_angle.py
+++ b/morfeus/cone_angle.py
@@ -69,7 +69,7 @@ class ConeAngle:
 
         # Check so that no atom is within vdW distance of atom 1
         within = check_distances(elements, coordinates, atom_1, radii=radii)
-        if within:
+        if len(within) > 0:
             atom_string = " ".join([str(i) for i in within])
             raise Exception("Atoms within vdW radius of central atom:", atom_string)
 

--- a/morfeus/visible_volume.py
+++ b/morfeus/visible_volume.py
@@ -75,7 +75,7 @@ class VisibleVolume:
 
         # Check so that no atom is within vdW distance of metal atom
         within = check_distances(elements, coordinates, metal_index, radii=radii)
-        if within:
+        if len(within) > 0:
             atom_string = " ".join([str(i) for i in within])
             raise Exception("Atoms within vdW radius of central atom:", atom_string)
 


### PR DESCRIPTION
Add new convenience function `get_excluded_from_connectivity` to exclude atoms based on connectivity when calculating fragments of larger molecules.

- Update `within_distance` to return empty list instead of None