### PR TITLE
Added pip support for RDKit/OpenBabel

### DIFF
--- a/docs/conformer.rst
+++ b/docs/conformer.rst
@@ -9,12 +9,22 @@ to the RDKit__ and OpenBabel__.
 .. __: https://www.rdkit.org
 .. __: http://openbabel.org/wiki/Main_Page
 
-OpenBabel and RDKit are avaible for install via, *e.g.*, the conda-forge:
+OpenBabel and RDKit are avaible for install via, *e.g.*, pip or conda-forge:
 
-.. code-block:: console
+.. tab:: pip
 
-  conda install -c conda-forge rdkit
-  conda install -c conda-forge openbabel
+  .. code-block:: console
+
+    $ pip install rdkit-pypi
+    $ pip install openbabel
+    
+
+.. tab:: conda
+
+  .. code-block:: console
+
+  $ conda install -c conda-forge rdkit
+  $ conda install -c conda-forge openbabel
 
 ******
 Module


### PR DESCRIPTION
> Installing RDKit from conda forge is a mess every now and then and you have to be careful of the environments.
> I added the recent [pip announcement](https://pypi.org/project/rdkit-pypi/) in the documentation for Morfeus-Conformer, to make the documentation better.

Here's an example installing RDKit with pip: https://github.com/iwatobipen/playground/blob/master/rdkit_from_pip.ipynb
