### PR TITLE
Handle no input coordinates in Gaussian log file

### DIFF
--- a/morfeus/local_force.py
+++ b/morfeus/local_force.py
@@ -870,9 +870,13 @@ class LocalForce:
             -1, 3
         )
 
+        if input_coordinates.size == 0:
+            input_coordinates = standard_coordinates
+
         if (
             not np.array_equal(input_coordinates, standard_coordinates)
             and standard_coordinates.size > 0
+            and input_coordinates.size > 0
         ):
             rotation_i_to_s = kabsch_rotation_matrix(
                 input_coordinates, standard_coordinates


### PR DESCRIPTION
Handles the situation where no input coordinates are present in the Gaussian log file read by LocalForce.

@rlaplaza, I think this fixes #53 by implanting what you suggested:
- Setting input coordinates = standard coordinates when input coordinates are missing
- Updating the conditional for the rotation of the input coordinates