### PR TITLE
Add native tblite backend

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,6 +71,7 @@ Features
 * Pyramidalization
 * Solvent accessible surface area
 * Sterimol parameters
+* TBLite native xTB properties
 * XTB electronic descriptors
 
 *****
@@ -120,6 +121,7 @@ both academic and commercial use.
    sasa
    solid_angle
    sterimol
+   tblite
    xtb
 
 .. toctree::

--- a/docs/tblite.rst
+++ b/docs/tblite.rst
@@ -1,0 +1,45 @@
+======
+TBLite
+======
+
+The :py:class:`TBLite <morfeus.tblite.TBLite>` class provides a native Python
+interface to the tblite__ library for xTB single-point properties.
+
+This is an optional backend for the subset of quantities that tblite exposes
+directly. It is not a drop-in replacement for :py:class:`XTB <morfeus.xtb.XTB>`,
+which still uses the ``xtb`` command line program for descriptors that depend on
+specialized workflows such as Fukui functions, IP/EA corrections, fractional
+occupation density, CM5 charges, or detailed solvation terms.
+
+******
+Module
+******
+
+The native backend can calculate total energies, Mulliken charges, bond orders,
+molecular dipoles, and frontier orbital energies when those quantities are
+available from the tblite result container.
+
+.. code-block:: python
+  :caption: Example
+
+  >>> from morfeus import TBLite, read_xyz
+  >>> elements, coordinates = read_xyz("ammonia.xyz")
+  >>> tblite = TBLite(elements, coordinates)
+  >>> tblite.get_energy()
+  -4.425...
+  >>> tblite.get_charges()
+  {1: -0.434..., 2: 0.144..., 3: 0.144..., 4: 0.144...}
+  >>> tblite.get_bond_order(1, 2)
+  0.97...
+
+The method can be selected with ``method=1``, ``method=2``, ``method="GFN1-xTB"``,
+``method="GFN2-xTB"``, or ``method="IPEA1-xTB"``. Molecular charge and unpaired
+electrons are set with ``charge=<int>`` and ``n_unpaired=<int>``.
+
+Implicit solvation can be requested with ``solvent=<str>`` and
+``solvation_model="alpb"`` or ``solvation_model="gbsa"``. Only the total
+single-point properties exposed by tblite are available; the solvation-specific
+descriptors from :py:class:`XTB <morfeus.xtb.XTB>` remain tied to the ``xtb``
+command line backend.
+
+.. __: https://tblite.readthedocs.io

--- a/environment-opt.yml
+++ b/environment-opt.yml
@@ -15,8 +15,10 @@ dependencies:
   - qcengine
   - rdkit
   - spyrmsd
+  - tblite
   - vtk
   - xtb>=6.7.1
   - xtb-python
   - pip:
       - pyberny
+      - tblite<0.5

--- a/morfeus/__init__.py
+++ b/morfeus/__init__.py
@@ -17,6 +17,7 @@ Modules:
     sasa: Solvent accessible surface area code
     solid_angle: Solid angle code
     sterimol: Sterimol code
+    tblite: Native tblite interface code
     typing: Typing code for arrays
     utils: Helper functions.
     visible_volume: Visible volume code
@@ -38,6 +39,7 @@ from morfeus.pyramidalization import Pyramidalization
 from morfeus.sasa import SASA
 from morfeus.solid_angle import SolidAngle
 from morfeus.sterimol import Sterimol
+from morfeus.tblite import TBLite
 from morfeus.visible_volume import VisibleVolume
 from morfeus.xtb import XTB
 
@@ -55,6 +57,7 @@ __all__ = [
     "SASA",
     "SolidAngle",
     "Sterimol",
+    "TBLite",
     "VisibleVolume",
     "XTB",
 ]

--- a/morfeus/tblite.py
+++ b/morfeus/tblite.py
@@ -1,0 +1,303 @@
+"""Native tblite interface code."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+import typing
+from typing import Any, cast
+
+import numpy as np
+
+from morfeus.data import (
+    ANGSTROM_TO_BOHR,
+    AU_TO_DEBYE,
+    HARTREE,
+    HARTREE_TO_EV,
+    K_B,
+)
+from morfeus.typing import Array1DFloat, Array2DFloat, ArrayLike2D
+from morfeus.utils import convert_elements, Import, requires_dependency
+
+if typing.TYPE_CHECKING:
+    from tblite.interface import Calculator
+
+
+class TBLite:
+    """Calculate xTB properties with the native tblite Python interface.
+
+    This class intentionally exposes only the subset of properties provided by
+    tblite result containers. Use :class:`morfeus.xtb.XTB` for descriptors that
+    depend on xtb CLI workflows such as Fukui functions, IP/EA corrections, FOD,
+    or detailed solvation terms.
+
+    Args:
+        elements: Elements as atomic symbols or numbers.
+        coordinates: Coordinates (A).
+        method: xTB method. Currently supports 1/GFN1-xTB, 2/GFN2-xTB,
+            and IPEA1-xTB.
+        charge: Molecular charge.
+        n_unpaired: Number of unpaired electrons.
+        solvent: Optional solvent for implicit solvation.
+        solvation_model: Solvation model, either "alpb" or "gbsa".
+        electronic_temperature: Electronic temperature (K).
+    """
+
+    _method_map: dict[str, str] = {
+        "1": "GFN1-xTB",
+        "gfn1": "GFN1-xTB",
+        "gfn1-xtb": "GFN1-xTB",
+        "2": "GFN2-xTB",
+        "gfn2": "GFN2-xTB",
+        "gfn2-xtb": "GFN2-xTB",
+        "ipea1": "IPEA1-xTB",
+        "ipea1-xtb": "IPEA1-xTB",
+    }
+
+    _solvation_models: dict[str, str] = {
+        "alpb": "alpb-solvation",
+        "gbsa": "gbsa-solvation",
+    }
+
+    def __init__(
+        self,
+        elements: Iterable[int] | Iterable[str],
+        coordinates: ArrayLike2D,
+        method: int | str = 2,
+        charge: int = 0,
+        n_unpaired: int | None = None,
+        solvent: str | None = None,
+        solvation_model: str = "alpb",
+        electronic_temperature: float | None = None,
+    ) -> None:
+        self._elements = np.array(convert_elements(elements, output="numbers"))
+        self._coordinates = np.array(coordinates)
+        self._charge = charge
+        self._n_unpaired = n_unpaired
+        self._solvent = solvent
+        self._electronic_temperature = electronic_temperature
+
+        method_key = str(method).lower()
+        try:
+            self._method = self._method_map[method_key]
+        except KeyError as error:
+            supported_methods = ", ".join(sorted(self._method_map))
+            raise ValueError(
+                f"Method {method!r} not supported. Choose one of: {supported_methods}."
+            ) from error
+
+        solvation_key = solvation_model.lower()
+        try:
+            self._solvation = self._solvation_models[solvation_key]
+        except KeyError as error:
+            supported_solvation = ", ".join(sorted(self._solvation_models))
+            raise ValueError(
+                "Solvation model "
+                f"{solvation_model!r} not supported. Choose one of: "
+                f"{supported_solvation}."
+            ) from error
+
+        self._results = TBLiteResults()
+
+    def get_bond_order(self, i: int, j: int) -> float:
+        """Return bond order between two atoms.
+
+        Args:
+            i: Index of atom 1 (1-indexed).
+            j: Index of atom 2 (1-indexed).
+
+        Returns:
+            Bond order between atoms i and j.
+
+        Raises:
+            ValueError: If no bond order exists between the given atoms.
+        """
+        bond_orders = self.get_bond_orders()
+        if (i, j) in bond_orders:
+            bond_order = bond_orders[(i, j)]
+        elif (j, i) in bond_orders:
+            bond_order = bond_orders[(j, i)]
+        else:
+            raise ValueError(f"No bond order calculated between atoms {i} and {j}.")
+
+        return bond_order
+
+    def get_bond_orders(self) -> dict[tuple[int, int], float]:
+        """Return bond orders."""
+        if self._results.bond_orders is None:
+            self._run_tblite()
+            self._results.bond_orders = cast(Array2DFloat, self._results.bond_orders)
+
+        bond_order_matrix = self._results.bond_orders
+        bond_orders = {}
+        rows, cols = np.triu_indices_from(bond_order_matrix, k=1)
+        for row, col in zip(rows, cols):
+            bond_order = float(bond_order_matrix[row, col])
+            if not np.isclose(bond_order, 0):
+                bond_orders[(row + 1, col + 1)] = round(bond_order, 12)
+
+        return bond_orders
+
+    def get_charges(self) -> dict[int, float]:
+        """Return atomic charges (1-indexed)."""
+        if self._results.charges is None:
+            self._run_tblite()
+            self._results.charges = cast(Array1DFloat, self._results.charges)
+
+        return {
+            i: float(charge) for i, charge in enumerate(self._results.charges, start=1)
+        }
+
+    def get_dipole(self) -> Array1DFloat:
+        """Return molecular dipole vector (a.u.)."""
+        if self._results.dipole is None:
+            self._run_tblite()
+            self._results.dipole = cast(Array1DFloat, self._results.dipole)
+
+        return self._results.dipole
+
+    def get_dipole_moment(self, unit: str = "au") -> float:
+        """Return molecular dipole moment.
+
+        Args:
+            unit: 'au' or 'debye'.
+
+        Returns:
+            Molecular dipole moment (a.u. or debye).
+
+        Raises:
+            ValueError: If given unit is not supported.
+        """
+        dipole_moment = float(np.linalg.norm(self.get_dipole()))
+        if unit == "au":
+            return round(dipole_moment, 8)
+        elif unit == "debye":
+            return round(dipole_moment * AU_TO_DEBYE, 8)
+        else:
+            raise ValueError("Unit must be either 'au' or 'debye'.")
+
+    def get_energy(self) -> float:
+        """Return total energy (Eh)."""
+        if self._results.total_energy is None:
+            self._run_tblite()
+            self._results.total_energy = cast(float, self._results.total_energy)
+
+        return self._results.total_energy
+
+    def get_homo(self, unit: str = "Eh") -> float:
+        """Return HOMO energy."""
+        homo, _ = self._get_frontier_orbitals()
+
+        return self._convert_orbital_energy(homo, unit)
+
+    def get_homo_lumo_gap(self, unit: str = "eV") -> float:
+        """Return HOMO-LUMO gap."""
+        homo, lumo = self._get_frontier_orbitals()
+        gap = lumo - homo
+
+        return self._convert_orbital_energy(gap, unit)
+
+    def get_lumo(self, unit: str = "Eh") -> float:
+        """Return LUMO energy."""
+        _, lumo = self._get_frontier_orbitals()
+
+        return self._convert_orbital_energy(lumo, unit)
+
+    def get_ea(self, corrected: bool = True) -> float:
+        """Raise for unsupported electron affinity calculations."""
+        raise NotImplementedError("Electron affinity requires the xtb CLI backend.")
+
+    def get_fukui(self, variety: str, corrected: bool = True) -> dict[int, float]:
+        """Raise for unsupported Fukui function calculations."""
+        raise NotImplementedError("Fukui functions require the xtb CLI backend.")
+
+    def get_ip(self, corrected: bool = True) -> float:
+        """Raise for unsupported ionization potential calculations."""
+        raise NotImplementedError("Ionization potential requires the xtb CLI backend.")
+
+    def _convert_orbital_energy(self, energy: float, unit: str) -> float:
+        """Convert orbital energy from Hartree."""
+        if unit == "Eh":
+            return energy
+        elif unit == "eV":
+            return energy * HARTREE_TO_EV
+        else:
+            raise ValueError("Unit must be either 'Eh' or 'eV'.")
+
+    def _get_frontier_orbitals(self) -> tuple[float, float]:
+        """Return HOMO and LUMO energies in Hartree."""
+        if (
+            self._results.orbital_energies is None
+            or self._results.orbital_occupations is None
+        ):
+            self._run_tblite()
+            self._results.orbital_energies = cast(
+                Array1DFloat, self._results.orbital_energies
+            )
+            self._results.orbital_occupations = cast(
+                Array1DFloat, self._results.orbital_occupations
+            )
+
+        energies = np.ravel(self._results.orbital_energies)
+        occupations = np.ravel(self._results.orbital_occupations)
+        order = np.argsort(energies)
+        energies = energies[order]
+        occupations = occupations[order]
+
+        occupied = np.where(occupations > 1e-8)[0]
+        unoccupied = np.where(occupations <= 1e-8)[0]
+        if len(occupied) == 0 or len(unoccupied) == 0:
+            raise ValueError("Could not determine frontier orbitals from tblite results.")
+
+        homo_index = occupied[-1]
+        lumo_candidates = unoccupied[unoccupied > homo_index]
+        if len(lumo_candidates) == 0:
+            raise ValueError("Could not determine LUMO from tblite results.")
+
+        return float(energies[homo_index]), float(energies[lumo_candidates[0]])
+
+    @requires_dependency(
+        [Import(module="tblite.interface", item="Calculator")], globals()
+    )
+    def _run_tblite(self) -> None:
+        """Run tblite single-point calculation and cache supported results."""
+        calculator = Calculator(
+            self._method,
+            self._elements,
+            self._coordinates * ANGSTROM_TO_BOHR,
+            charge=float(self._charge),
+            uhf=self._n_unpaired,
+        )
+        calculator.set("verbosity", 0)
+        if self._electronic_temperature is not None:
+            calculator.set(
+                "temperature", float(self._electronic_temperature) * K_B / HARTREE
+            )
+        if self._solvent is not None:
+            calculator.add(self._solvation, self._solvent)
+
+        result = calculator.singlepoint()
+        self._extract_result(result)
+
+    def _extract_result(self, result: Any) -> None:
+        """Extract supported quantities from a tblite result container."""
+        self._results.total_energy = float(result.get("energy"))
+        self._results.charges = np.array(result.get("charges"))
+        self._results.bond_orders = np.array(result.get("bond-orders"))
+        self._results.dipole = np.array(result.get("dipole"))
+        self._results.orbital_energies = np.array(result.get("orbital-energies"))
+        self._results.orbital_occupations = np.array(
+            result.get("orbital-occupations")
+        )
+
+
+@dataclass
+class TBLiteResults:
+    """Stores native tblite results."""
+
+    charges: Array1DFloat | None = None
+    bond_orders: Array2DFloat | None = None
+    dipole: Array1DFloat | None = None
+    total_energy: float | None = None
+    orbital_energies: Array1DFloat | None = None
+    orbital_occupations: Array1DFloat | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,9 @@ known_first_party = ["morfeus"]
 DEP001 = ["libconeangle"]
 
 [tool.pytest.ini_options]
-addopts = "-m 'not (benchmark or xtb)'"
+addopts = "-m 'not (benchmark or xtb or tblite)'"
 markers = [
     "benchmark: mark a test as method benchmark",
+    "tblite: mark a test as requiring the tblite dependency",
     "xtb: mark a test as requiring the xtb dependency",
 ]

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -9,5 +9,6 @@ pyvistaqt
 qcengine
 rdkit
 spyrmsd
+tblite<0.5
 vtk
 xtb-python

--- a/tests/test_tblite.py
+++ b/tests/test_tblite.py
@@ -1,0 +1,68 @@
+"""Test native tblite code."""
+
+import numpy as np
+import pytest
+
+from morfeus import TBLite
+
+pytest.importorskip("tblite.interface", exc_type=ImportError)
+
+pytestmark = pytest.mark.tblite
+
+ELEMENTS = ["O", "H", "H"]
+COORDINATES = np.array(
+    [
+        [0.000000, 0.000000, 0.000000],
+        [0.758602, 0.000000, 0.504284],
+        [-0.758602, 0.000000, 0.504284],
+    ]
+)
+
+
+def test_tblite_single_point_properties():
+    """Test supported single-point properties."""
+    tblite = TBLite(ELEMENTS, COORDINATES)
+
+    energy = tblite.get_energy()
+    charges = tblite.get_charges()
+    bond_orders = tblite.get_bond_orders()
+    dipole = tblite.get_dipole()
+
+    assert isinstance(energy, float)
+    assert len(charges) == len(ELEMENTS)
+    assert sum(charges.values()) == pytest.approx(0, abs=1e-6)
+    assert tblite.get_bond_order(1, 2) == bond_orders[(1, 2)]
+    assert tblite.get_bond_order(1, 3) == bond_orders[(1, 3)]
+    assert dipole.shape == (3,)
+    assert tblite.get_dipole_moment(unit="debye") > 0
+
+
+def test_tblite_frontier_orbitals():
+    """Test frontier orbital access."""
+    tblite = TBLite(ELEMENTS, COORDINATES)
+
+    homo = tblite.get_homo()
+    lumo = tblite.get_lumo()
+
+    assert homo < lumo
+    assert tblite.get_homo_lumo_gap(unit="eV") > 0
+
+
+def test_tblite_unsupported_descriptors():
+    """Test clear errors for xtb CLI-only descriptors."""
+    tblite = TBLite(ELEMENTS, COORDINATES)
+
+    with pytest.raises(NotImplementedError, match="xtb CLI backend"):
+        tblite.get_ip()
+    with pytest.raises(NotImplementedError, match="xtb CLI backend"):
+        tblite.get_ea()
+    with pytest.raises(NotImplementedError, match="xtb CLI backend"):
+        tblite.get_fukui("nucleophilicity")
+
+
+def test_tblite_validation():
+    """Test validation of unsupported options."""
+    with pytest.raises(ValueError, match="Method"):
+        TBLite(ELEMENTS, COORDINATES, method="ptb")
+    with pytest.raises(ValueError, match="Solvation model"):
+        TBLite(ELEMENTS, COORDINATES, solvation_model="unknown")


### PR DESCRIPTION
Introduce a separate optional TBLite interface for native xTB single-point properties while keeping the existing xtb CLI backend intact for the full descriptor surface.

Currently supported through tblite result containers:
- total energies
- Mulliken charges
- bond orders
- molecular dipoles
- frontier orbital energies and HOMO-LUMO gaps

The migration is intentionally incomplete until tblite exposes the remaining quantities that MORFEUS currently obtains by parsing xtb CLI output: IP/EA corrections, Fukui functions, fractional occupation density, CM5 charges, covCN and polarizability details, and detailed solvation terms. Nonetheless, this is necessary because eventually we will need tblite to access the newest semiempirical methods from Grimme, such as g-XTB. Take it as a suggestion in the right direction if you want, but I'd rather help that open a feature request :D

I added and ran basic tests locally but cannot promise all is perfect.