### PR TITLE
fix: update type annotations that failed with newer mypy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-01-08
+## [Unreleased] - 2026-05-18
 
 ### Fixed
 - Compatibility issue with Python 3.14 where command-line interface failed due to `fire` library's requirement for `__name__` attribute on `functools.partial` objects
+- Update type annotations which were throwing errors with newer versions of mypy
+
 
 ## [0.8.0] - 2025-11-11
 

--- a/morfeus/bite_angle.py
+++ b/morfeus/bite_angle.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 import numpy as np
 
 from morfeus.io import read_geometry
-from morfeus.typing import Array1DFloat, Array2DFloat, ArrayLike1D, ArrayLike2D
+from morfeus.typing import Array1DFloat, ArrayLike1D, ArrayLike2D
 
 
 class BiteAngle:
@@ -57,7 +57,7 @@ class BiteAngle:
         if ref_atoms is not None and ref_vector is not None:
             raise ValueError("ref_atoms and ref_vector cannot be set at the same time.")
 
-        coordinates: Array2DFloat = np.asarray(coordinates)
+        coordinates = np.asarray(coordinates)
 
         # Construct vectors
         v_1 = coordinates[ligand_index_1 - 1] - coordinates[metal_index - 1]

--- a/morfeus/buried_volume.py
+++ b/morfeus/buried_volume.py
@@ -144,7 +144,7 @@ class BuriedVolume:
             raise IndexError("Atom indices should not be 0 (1-indexed).")
 
         # Get center and and reortient coordinate system
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
         center = coordinates[metal_index - 1]
         coordinates -= center
 
@@ -192,7 +192,7 @@ class BuriedVolume:
         # Getting radii if they are not supplied
         if radii is None:
             radii = get_radii(elements, radii_type=radii_type, scale=radii_scale)
-        radii: Array1DFloat = np.array(radii)
+        radii = np.array(radii)
 
         # Get list of atoms as Atom objects
         atoms = []
@@ -307,7 +307,7 @@ class BuriedVolume:
         self, center: ArrayLike1D, radius: float, density: float
     ) -> None:
         """Compute buried volume."""
-        center: Array1DFloat = np.array(center)
+        center = np.array(center)
         # Construct sphere at metal center
         sphere = Sphere(
             center, radius, method="projection", density=density, filled=True
@@ -464,9 +464,9 @@ class BuriedVolume:
             raise ValueError("Must give z-axis atoms when instantiating BuriedVolume.")
         # Set up coordinates
         atoms = self._atoms
-        center: Array1DFloat = np.array(self._sphere.center)
+        center = np.array(self._sphere.center)
         all_coordinates: Array2DFloat = self._all_coordinates
-        coordinates: Array2DFloat = np.array([atom.coordinates for atom in atoms])
+        coordinates = np.array([atom.coordinates for atom in atoms])
 
         # Translate coordinates
         all_coordinates -= center
@@ -523,7 +523,7 @@ class BuriedVolume:
             z.append(z_max)
 
         # Create interaction surface
-        z: Array2DFloat = np.array(z).reshape(len(x_), len(y_))
+        z = np.array(z).reshape(len(x_), len(y_))
 
         # Plot surface
         fig, ax = plt.subplots()

--- a/morfeus/calculators.py
+++ b/morfeus/calculators.py
@@ -11,7 +11,7 @@ from scipy.spatial.distance import cdist
 from morfeus.d3_data import c6_reference_data, r2_r4
 from morfeus.data import ANGSTROM_TO_BOHR
 from morfeus.geometry import Atom
-from morfeus.typing import Array1DFloat, Array1DInt, Array2DFloat, ArrayLike2D
+from morfeus.typing import Array1DFloat, ArrayLike2D
 from morfeus.utils import convert_elements, get_radii, Import, requires_dependency
 
 if typing.TYPE_CHECKING:
@@ -53,7 +53,7 @@ class D4Grimme:
         order: int = 8,
     ) -> None:
         # Convert elements to atomic numbers
-        elements: Array1DInt = np.array(convert_elements(elements, output="numbers"))
+        elements = np.array(convert_elements(elements, output="numbers"))
         coordinates = np.array(coordinates) * ANGSTROM_TO_BOHR
 
         # Do calculation
@@ -113,7 +113,7 @@ class D3Calculator:
     ) -> None:
         # Convert elements to atomic numbers
         elements = convert_elements(elements, output="numbers")
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
 
         # Load the covalent radii
         radii = get_radii(elements, radii_type="pyykko")
@@ -133,10 +133,10 @@ class D3Calculator:
         k_3 = 4
         for cn_atom in atoms:
             # Get coordinates and radii of all other atoms
-            other_coordinates: Array2DFloat = np.array(
+            other_coordinates = np.array(
                 [atom.coordinates for atom in atoms if atom is not cn_atom]
             )
-            other_radii: Array1DFloat = np.array(
+            other_radii = np.array(
                 [atom.radius for atom in atoms if atom is not cn_atom]
             )
 
@@ -199,15 +199,13 @@ class D3Calculator:
                 c_n_coefficients[key].append(value)
 
         # Set up attributes
-        coordination_numbers: Array1DFloat = np.array(
+        coordination_numbers = np.array(
             [atom.coordination_number for atom in self._atoms]
         )
-        c_n_coefficients: Array1DFloat = {
+        self._atoms = atoms
+        self.c_n_coefficients = {
             key: np.array(value) for key, value in c_n_coefficients.items()
         }
-
-        self._atoms = atoms
-        self.c_n_coefficients = c_n_coefficients
         self.coordination_numbers = coordination_numbers
 
     def __repr__(self) -> str:

--- a/morfeus/cone_angle.py
+++ b/morfeus/cone_angle.py
@@ -16,7 +16,7 @@ from morfeus.data import atomic_symbols, jmol_colors
 from morfeus.geometry import Atom, Cone
 from morfeus.io import read_geometry
 from morfeus.plotting import get_drawing_cone
-from morfeus.typing import Array1DFloat, Array2DFloat, ArrayLike1D, ArrayLike2D
+from morfeus.typing import Array2DFloat, ArrayLike1D, ArrayLike2D
 from morfeus.utils import (
     check_distances,
     convert_elements,
@@ -73,12 +73,12 @@ class ConeAngle:
 
         # Convert elements to atomic numbers if they are symbols
         elements = convert_elements(elements, output="numbers")
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
 
         # Get radii if they are not supplied
         if radii is None:
             radii = get_radii(elements, radii_type=radii_type)
-        radii: Array1DFloat = np.array(radii)
+        radii = np.array(radii)
 
         # Check so that no atom is within vdW distance of atom 1
         within = check_distances(elements, coordinates, atom_1, radii=radii)
@@ -184,7 +184,7 @@ class ConeAngle:
             upper_bound: Upper bound to apex angle (radians)
         """
         # Calculate unit vector to centroid
-        coordinates: Array2DFloat = np.array([atom.coordinates for atom in self._atoms])
+        coordinates = np.array([atom.coordinates for atom in self._atoms])
         centroid_vector = np.mean(coordinates, axis=0)
         centroid_unit_vector = centroid_vector / np.linalg.norm(centroid_vector)
 
@@ -335,8 +335,8 @@ class ConeAngle:
 
         # Determine direction and extension of cone
         angle = math.degrees(self._cone.angle)
-        coordinates: Array2DFloat = np.array([atom.coordinates for atom in self._atoms])
-        radii: Array1DFloat = np.array([atom.radius for atom in self._atoms])
+        coordinates = np.array([atom.coordinates for atom in self._atoms])
+        radii = np.array([atom.radius for atom in self._atoms])
         if angle > 180:
             normal = -self._cone.normal
         else:
@@ -421,11 +421,9 @@ def _get_three_atom_cones(atom_i: Atom, atom_j: Atom, atom_k: Atom) -> list[Cone
     m_k = atom_k.cone.normal
 
     # Setup matrices
-    u: Array1DFloat = np.array([math.cos(beta_i), math.cos(beta_j), math.cos(beta_k)])
-    v: Array1DFloat = np.array([math.sin(beta_i), math.sin(beta_j), math.sin(beta_k)])
-    N: Array2DFloat = np.array(
-        [np.cross(m_j, m_k), np.cross(m_k, m_i), np.cross(m_i, m_j)]
-    ).T
+    u = np.array([math.cos(beta_i), math.cos(beta_j), math.cos(beta_k)])
+    v = np.array([math.sin(beta_i), math.sin(beta_j), math.sin(beta_k)])
+    N = np.array([np.cross(m_j, m_k), np.cross(m_k, m_i), np.cross(m_i, m_j)]).T
     P: Array2DFloat = N.T @ N
     gamma = np.dot(m_i, np.cross(m_j, m_k))
 

--- a/morfeus/conformer.py
+++ b/morfeus/conformer.py
@@ -68,8 +68,8 @@ def boltzmann_average_dT(
     Returns:
         derivative: Derivative of Boltzmann average.
     """
-    energies: Array1DFloat = np.array(energies)
-    properties: Array1DFloat = np.array(properties)
+    energies = np.array(energies)
+    properties = np.array(properties)
 
     # Calculate Boltzmann averaged properties
     avg_prop_en = boltzmann_statistic(
@@ -111,7 +111,7 @@ def boltzmann_statistic(
     Raises:
         ValueError: When statistic not specified correctly
     """
-    properties: Array1DFloat = np.array(properties)
+    properties = np.array(properties)
 
     # Get conformer weights
     weights = boltzmann_weights(energies, temperature)
@@ -151,7 +151,7 @@ def boltzmann_weights(
     Returns:
         weights: Conformer weights (normalized to unity)
     """
-    energies: Array1DFloat = np.array(energies)
+    energies = np.array(energies)
     energies -= energies.min()
     terms = np.exp(-energies / (K_B / HARTREE * temperature))
     weights: Array1DFloat = terms / np.sum(terms)
@@ -262,7 +262,7 @@ class ConformerEnsemble:
         formal_charges: ArrayLike1D | None = None,
         ref_cip_label: tuple[str, ...] | None = None,
     ) -> None:
-        elements: Array1DInt = np.array(convert_elements(elements, output="numbers"))
+        elements = np.array(convert_elements(elements, output="numbers"))
         self.elements = elements
 
         if conformer_coordinates is None:
@@ -683,7 +683,7 @@ class ConformerEnsemble:
         Returns:
             conformer_coordinates: Conformer coordinates (Å)
         """
-        conformer_coordinates: Array3DFloat = np.array(
+        conformer_coordinates = np.array(
             [conformer.coordinates for conformer in self.conformers]
         )
 
@@ -695,9 +695,7 @@ class ConformerEnsemble:
         Returns:
             degeneriacies: Degeneracies
         """
-        degeneracies: Array1DInt = np.array(
-            [conformer.degeneracy for conformer in self.conformers]
-        )
+        degeneracies = np.array([conformer.degeneracy for conformer in self.conformers])
 
         return degeneracies
 
@@ -707,9 +705,7 @@ class ConformerEnsemble:
         Returns:
             energies: Energy (a.u.)
         """
-        energies: Array1DFloat = np.array(
-            [conformer.energy for conformer in self.conformers]
-        )
+        energies = np.array([conformer.energy for conformer in self.conformers])
         return energies
 
     def get_properties(self) -> dict[str, Array1DFloat]:
@@ -722,11 +718,8 @@ class ConformerEnsemble:
         for conformer in self.conformers:
             for key, value in conformer.properties.items():
                 properties.setdefault(key, []).append(value)
-        properties: dict[str, Array1DFloat] = {
-            key: np.array(value) for key, value in properties.items()
-        }
 
-        return properties
+        return {key: np.array(value) for key, value in properties.items()}
 
     def get_relative_energies(
         self, unit: str = "kcal/mol", relative: bool = True
@@ -1045,7 +1038,7 @@ class ConformerEnsemble:
             ValueError: When number of conformer coordinates is different from number of
                 conformers
         """
-        conformer_coordinates: Array3DFloat = np.array(conformer_coordinates)
+        conformer_coordinates = np.array(conformer_coordinates)
         if len(conformer_coordinates) != self.n_conformers:
             msg = (
                 f"Number of coordinates ({len(conformer_coordinates)}) "
@@ -1070,7 +1063,7 @@ class ConformerEnsemble:
             ValueError: When number of degeneracies is different from number of
                 conformers
         """
-        degeneracies: Array1DInt = np.array(degeneracies)
+        degeneracies = np.array(degeneracies)
         if len(degeneracies) != self.n_conformers:
             msg = (
                 f"Number of degeneracies ({len(degeneracies)}) "
@@ -1095,7 +1088,7 @@ class ConformerEnsemble:
             ValueError: When number of energies is different from number of
                 conformers
         """
-        energies: Array1DFloat = np.array(energies)
+        energies = np.array(energies)
         if len(energies) != self.n_conformers:
             msg = (
                 f"Number of energies ({len(energies)}) != number of "
@@ -1256,7 +1249,7 @@ class ConformerEnsemble:
         degeneracies: ArrayLike1D | None = None,
         properties: Mapping[str, ArrayLike1D] | None = None,
     ) -> None:
-        conformer_coordinates: Array3DFloat = np.array(conformer_coordinates)
+        conformer_coordinates = np.array(conformer_coordinates)
         n_conformers = len(conformer_coordinates)
 
         energies_: np.ndarray
@@ -1312,7 +1305,7 @@ class ConformerEnsemble:
             result = result.reshape(1, -1)
         rmsds = result[:, 1:]
 
-        rmsds: Array2DFloat = rmsds[i_s - 1, :][:, j_s - 1]
+        rmsds = rmsds[i_s - 1, :][:, j_s - 1]
 
         return rmsds
 
@@ -1347,7 +1340,7 @@ class ConformerEnsemble:
                 )
             row_rmsds = np.genfromtxt(process.stdout.splitlines(), usecols=(-1))  # type: ignore
             rmsds.append(row_rmsds)
-        rmsds: Array2DFloat = np.vstack(rmsds)
+        rmsds = np.vstack(rmsds)
 
         return rmsds
 
@@ -1385,7 +1378,7 @@ class ConformerEnsemble:
                 rmsd = align.GetRMSD()
                 rmsds_row.append(rmsd)
             rmsds.append(rmsds_row)
-        rmsds: Array2DFloat = np.array(rmsds)
+        rmsds = np.array(rmsds)
 
         return rmsds
 
@@ -1436,7 +1429,7 @@ class ConformerEnsemble:
             rmsds_row: list[float] = []
             AllChem.AlignMolConformers(ref_mol, atomIds=atom_ids, RMSlist=rmsds_row)
             rmsds.append(rmsds_row)
-        rmsds: Array2DFloat = np.array(rmsds)
+        rmsds = np.array(rmsds)
 
         return rmsds
 
@@ -1493,9 +1486,8 @@ class ConformerEnsemble:
                     )
                     row_rmsds.append(rmsd)
             rmsds.append(np.array(row_rmsds))
-        rmsds: Array2DFloat = np.vstack(rmsds)
 
-        return rmsds
+        return np.vstack(rmsds)
 
     def update_mol(self) -> ConformerEnsemble:
         """Update Mol object with conformers."""
@@ -1812,7 +1804,7 @@ def conformers_from_rdkit(  # noqa: C901
         mol = Chem.MolFromSmiles(mol)
     except TypeError:
         pass
-    mol: Chem.Mol = Chem.AddHs(mol)
+    mol = Chem.AddHs(mol)
 
     # If n_conformers is not set, set number of conformers based on number of
     # rotatable bonds
@@ -1895,7 +1887,7 @@ def _add_conformers_to_mol(mol: Chem.Mol, conformer_coordinates: ArrayLike3D) ->
         mol: RDKit mol object
         conformer_coordinates: Conformer coordinates (Å)
     """
-    conformer_coordinates: Array3DFloat = np.array(conformer_coordinates)
+    conformer_coordinates = np.array(conformer_coordinates)
     if len(conformer_coordinates.shape) == 2:
         conformer_coordinates.reshape(-1, conformer_coordinates.shape[0], 3)
 
@@ -1914,13 +1906,13 @@ def _extract_from_mol(
     """Extract information from RDKit Mol object with conformers."""
     # Take out elements, coordinates and connectivity matrix
     elements: list[str] = [atom.GetSymbol() for atom in mol.GetAtoms()]
-    charges: Array1DInt = np.array([atom.GetFormalCharge() for atom in mol.GetAtoms()])
+    charges = np.array([atom.GetFormalCharge() for atom in mol.GetAtoms()])
 
     conformer_coordinates = []
     for conformer in mol.GetConformers():
         coordinates = conformer.GetPositions()
         conformer_coordinates.append(coordinates)
-    conformer_coordinates: Array3DFloat = np.array(conformer_coordinates)
+    conformer_coordinates = np.array(conformer_coordinates)
 
     connectivity_matrix: Array2DFloat = Chem.GetAdjacencyMatrix(mol, useBO=True)
 
@@ -1940,8 +1932,8 @@ def _extract_from_ob_mol(
 ) -> tuple[Array1DInt, Array3DFloat, Array2DInt, Array1DInt]:
     """Extract information from Openbabel OBMol object with conformers."""
     py_mol = pybel.Molecule(ob_mol)
-    elements: Array1DInt = np.array([atom.atomicnum for atom in py_mol.atoms])
-    charges: Array1DInt = np.array([atom.formalcharge for atom in py_mol.atoms])
+    elements = np.array([atom.atomicnum for atom in py_mol.atoms])
+    charges = np.array([atom.formalcharge for atom in py_mol.atoms])
 
     n_atoms = len(py_mol.atoms)
     connectivity_matrix: Array2DInt = np.zeros((n_atoms, n_atoms), dtype=int)
@@ -1956,9 +1948,9 @@ def _extract_from_ob_mol(
     conformer_coordinates = []
     for i in range(ob_mol.NumConformers()):
         ob_mol.SetConformer(i)
-        coordinates: Array2DFloat = np.array([atom.coords for atom in py_mol.atoms])
+        coordinates = np.array([atom.coords for atom in py_mol.atoms])
         conformer_coordinates.append(coordinates)
-    conformer_coordinates: Array3DFloat = np.array(conformer_coordinates)
+    conformer_coordinates = np.array(conformer_coordinates)
 
     return elements, conformer_coordinates, connectivity_matrix, charges
 
@@ -1990,8 +1982,8 @@ def _get_ob_mol(
         charges_ = np.array(charges)
     charges = charges_
 
-    connectivity_matrix: Array2DInt = np.array(connectivity_matrix)
-    coordinates: Array2DFloat = np.array(coordinates)
+    connectivity_matrix = np.array(connectivity_matrix)
+    coordinates = np.array(coordinates)
 
     mol = ob.OBMol()
 
@@ -2035,8 +2027,8 @@ def _get_rdkit_mol(
     else:
         charges_ = np.array(charges)
     charges = charges_
-    conformer_coordinates: Array3DFloat = np.array(conformer_coordinates)
-    connectivity_matrix: Array2DInt = np.array(connectivity_matrix)
+    conformer_coordinates = np.array(conformer_coordinates)
+    connectivity_matrix = np.array(connectivity_matrix)
 
     mol = Chem.RWMol()
 

--- a/morfeus/dispersion.py
+++ b/morfeus/dispersion.py
@@ -20,7 +20,6 @@ from morfeus.typing import (
     Array1DFloat,
     Array1DInt,
     Array2DFloat,
-    Array2DInt,
     ArrayLike1D,
     ArrayLike2D,
 )
@@ -106,7 +105,7 @@ class Dispersion:
 
         # Converting elements to atomic numbers if the are symbols
         elements = convert_elements(elements, output="numbers")
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
 
         # Set excluded atoms
         all_atoms = set(range(1, len(elements) + 1))
@@ -128,7 +127,7 @@ class Dispersion:
         # Getting radii if they are not supplied
         if radii is None:
             radii = get_radii(elements, radii_type=radii_type)
-        radii: Array1DFloat = np.array(radii)
+        radii = np.array(radii)
 
         self._radii = radii
 
@@ -250,9 +249,9 @@ class Dispersion:
         """
         # Read the vertices and faces from the Multiwfn output file
         parser = VertexParser(file)
-        vertices: Array2DFloat = np.array(parser.vertices)
-        faces: Array2DInt = np.array(parser.faces)
-        faces: Array2DInt = np.insert(faces, 0, values=3, axis=1)
+        vertices = np.array(parser.vertices)
+        faces = np.array(parser.faces)
+        faces = np.insert(faces, 0, values=3, axis=1)
 
         # Construct surface and fix it with pymeshfix
         surface = pv.PolyData(vertices, faces)
@@ -274,15 +273,15 @@ class Dispersion:
         self.volume = self._surface.volume
 
         # Assign face centers to atoms according to Voronoi partitioning
-        coordinates: Array2DFloat = np.array([atom.coordinates for atom in self._atoms])
-        points: Array2DFloat = np.array(self._surface.cell_centers().points)
+        coordinates = np.array([atom.coordinates for atom in self._atoms])
+        points = np.array(self._surface.cell_centers().points)
         kd_tree = scipy.spatial.cKDTree(coordinates)
         _, point_regions = kd_tree.query(points, k=1)
         point_regions = point_regions + 1
 
         # Compute faces areas
         area_data = self._surface.compute_cell_sizes()
-        areas: Array1DFloat = np.array(area_data.cell_data["Area"])
+        areas = np.array(area_data.cell_data["Area"])
 
         # Assign face centers and areas to atoms
         atom_areas = {}
@@ -343,14 +342,14 @@ class Dispersion:
             self: Self
         """
         # Set up atoms and coefficients that are part of the calculation
-        atom_indices: Array1DInt = np.array(
+        atom_indices = np.array(
             [
                 atom.index - 1
                 for atom in self._atoms
                 if atom.index not in self._excluded_atoms
             ]
         )
-        coordinates: Array2DFloat = np.array([atom.coordinates for atom in self._atoms])
+        coordinates = np.array([atom.coordinates for atom in self._atoms])
         coordinates = coordinates[atom_indices]
         c_n_coefficients = dict(self._c_n_coefficients)
         for key, value in c_n_coefficients.items():
@@ -454,7 +453,7 @@ class Dispersion:
         """
         # Set up atoms and coordinates
         elements = [atom.element for atom in self._atoms]
-        coordinates: Array2DFloat = np.array([atom.coordinates for atom in self._atoms])
+        coordinates = np.array([atom.coordinates for atom in self._atoms])
 
         calculators = {
             "id3": D3Calculator,

--- a/morfeus/geometry.py
+++ b/morfeus/geometry.py
@@ -158,7 +158,7 @@ class Cone:
         Raises:
             ValueError: When method not supported
         """
-        points: Array2DFloat = np.array(points)
+        points = np.array(points)
         if method in ["cross", "dot"]:
             # Calculate radius of cone at distance of each point
             cone_distances = np.dot(points, self.normal)
@@ -418,11 +418,11 @@ class Bond:
         Returns:
             b_vector: Vector of B matrix (a.u.)
         """
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
         i, j = self.i - 1, self.j - 1
         v = (coordinates[i] - coordinates[j]) * ANGSTROM_TO_BOHR
         r = np.linalg.norm(v)
-        grad: Array1DFloat = np.array([v / r, -v / r])
+        grad = np.array([v / r, -v / r])
 
         b_vector = np.zeros(coordinates.size)
         b_vector[i * 3 : i * 3 + 3] = grad[0]
@@ -484,7 +484,7 @@ class Angle:
         Returns:
             b_vector: Vector of B matrix (a.u.)
         """
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
         i, j, k = self.i - 1, self.j - 1, self.k - 1
         v_1 = (coordinates[i] - coordinates[j]) * ANGSTROM_TO_BOHR
         v_2 = (coordinates[k] - coordinates[j]) * ANGSTROM_TO_BOHR
@@ -582,7 +582,7 @@ class Dihedral:
         Returns:
             b_vector: Vector of B matrix (a.u.)
         """
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
         i, j, k, l = self.i - 1, self.j - 1, self.k - 1, self.l - 1
         v_1 = (coordinates[i] - coordinates[j]) * ANGSTROM_TO_BOHR
         v_2 = (coordinates[l] - coordinates[k]) * ANGSTROM_TO_BOHR
@@ -781,7 +781,7 @@ class InternalCoordinates:
         Returns:
             B_matrix: B matrix
         """
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
         b_vectors = []
         for internal_coordinate in self.internal_coordinates:
             b_vectors.append(internal_coordinate.get_b_vector(coordinates))
@@ -811,9 +811,9 @@ def rotate_coordinates(
     Returns:
         rotated_coordinates: Rotated coordinates.
     """
-    coordinates: Array2DFloat = np.array(coordinates)
-    vector: Array1DFloat = np.array(vector)
-    axis: Array1DFloat = np.array(axis)
+    coordinates = np.array(coordinates)
+    vector = np.array(vector)
+    axis = np.array(axis)
 
     # Get real part of quaternion
     real = np.dot(vector, axis).reshape(1) + 1
@@ -853,8 +853,8 @@ def kabsch_rotation_matrix(
     Returns:
         R: Rotation matrix
     """
-    P: Array2DFloat = np.array(P)
-    Q: Array2DFloat = np.array(Q)
+    P = np.array(P)
+    Q = np.array(Q)
 
     # Calculate centroids and center coordinates
     if center:
@@ -893,8 +893,8 @@ def sphere_line_intersection(
     Returns:
         intersection_points: Intersection points
     """
-    vector: Array1DFloat = np.array(vector)
-    center: Array1DFloat = np.array(center)
+    vector = np.array(vector)
+    center = np.array(center)
 
     # Set up points
     p_1 = vector

--- a/morfeus/io.py
+++ b/morfeus/io.py
@@ -59,7 +59,7 @@ class CrestParser:
             strip_line = line.strip().split()
             if len(strip_line) != 1:
                 degeneracies.append(int(strip_line[0]))
-        degeneracies: Array1DInt = np.array(degeneracies)
+        degeneracies = np.array(degeneracies)
 
         with open(path / "crest.energies") as f:
             lines = f.readlines()
@@ -157,7 +157,7 @@ class CubeParser:
             data.extend(line_data)
 
         # Create array
-        S: Array2DFloat = np.array(data).reshape(X.shape)
+        S = np.array(data).reshape(X.shape)
 
         # Set up attributes
         self.X = X
@@ -264,8 +264,8 @@ class D4Parser:
                 c6_coefficients.append(c6)
             if "C6AA" in line:
                 read = True
-        c6_coefficients: Array1DFloat = np.array(c6_coefficients)
-        c8_coefficients: Array1DFloat = np.array(
+        c6_coefficients = np.array(c6_coefficients)
+        c8_coefficients = np.array(
             [
                 3 * c6 * r2_r4[element] ** 2
                 for c6, element in zip(c6_coefficients, elements)
@@ -390,10 +390,8 @@ def read_gjf(file: str | PathLike) -> tuple[Array1DAny, Array1DFloat]:
             elements.append(element)
         atom_coordinates = [float(i) for i in split_line[1:]]
         coordinates.append(atom_coordinates)
-    elements: Array1DInt | Array1DStr = np.array(elements)
-    coordinates: Array2DFloat = np.array(coordinates)
 
-    return elements, coordinates
+    return np.array(elements), np.array(coordinates)
 
 
 def read_geometry(
@@ -446,8 +444,8 @@ def read_xyz(
         lines = f.readlines()
 
     # Loop over lines and store elements and coordinates
-    elements: list[int | str] = []
-    coordinates: list[list[float]] = []
+    elements = []
+    coordinates = []
     n_atoms = int(lines[0].strip())
     line_chunks = zip(*[iter(lines)] * (n_atoms + 2))
     for line_chunk in line_chunks:
@@ -461,9 +459,7 @@ def read_xyz(
                 [float(strip_line[1]), float(strip_line[2]), float(strip_line[3])]
             )
     elements = np.array(elements)[:n_atoms]
-    coordinates: Array2DFloat | Array3DFloat = np.array(coordinates).reshape(
-        -1, n_atoms, 3
-    )
+    coordinates = np.array(coordinates).reshape(-1, n_atoms, 3)
     if coordinates.shape[0] == 1:
         coordinates = coordinates[0]
 
@@ -530,16 +526,14 @@ def write_xyz(
     """
     # Convert elements to symbols
     symbols = convert_elements(elements, output="symbols")
-    coordinates: Array2DFloat | Array3DFloat = np.array(coordinates).reshape(
-        -1, len(symbols), 3
-    )
+    coordinates = np.array(coordinates).reshape(-1, len(symbols), 3)
     if comments is None:
         comments = [""] * len(coordinates)
 
     # Write the xyz file
     with open(file, "w") as f:
         for coord, comment in zip(coordinates, comments):
-            xyz_string = get_xyz_string(symbols, coord, comment=comment)
+            xyz_string = get_xyz_string(symbols, coord.tolist(), comment=comment)
             f.write(xyz_string)
 
 

--- a/morfeus/local_force.py
+++ b/morfeus/local_force.py
@@ -191,7 +191,7 @@ class LocalForce:
                 k_s.append(k)
             else:
                 k_s.append(0.0)
-        k_s: Array1DFloat = np.array(k_s)
+        k_s = np.array(k_s)
 
         # Scale force constants due to projection of imaginary normal modes
         if project_imag and self.n_imag > 0:
@@ -489,7 +489,7 @@ class LocalForce:
         n_imag: int
         atomic_numbers: list[int] = []
         masses: list[float] = []
-        coordinates: list[float] = []
+        coordinates = []
 
         # Parse fchk file
         for line in lines:
@@ -569,15 +569,15 @@ class LocalForce:
             elif "Current cartesian coordinates " in line:
                 read_coordinates = True
         # Take out normal mode force constants
-        force_constants: Array1DFloat = np.array(vib_e2[n_modes * 2 : n_modes * 3])
+        force_constants = np.array(vib_e2[n_modes * 2 : n_modes * 3])
 
         # Construct force constant matrix from lower triangular matrix
         fc_matrix: Array2DFloat = np.zeros((n_atoms * 3, n_atoms * 3), dtype=float)
         fc_matrix[np.tril_indices_from(fc_matrix)] = hessian
-        fc_matrix: Array2DFloat = np.triu(fc_matrix.T, 1) + fc_matrix
+        fc_matrix = np.triu(fc_matrix.T, 1) + fc_matrix
 
         # Take out the internal coordinates
-        internal_coordinates: Array1DInt = np.array(internal_coordinates)
+        internal_coordinates = np.array(internal_coordinates)
         coordinate: Array1DInt
         for _, coordinate in enumerate(np.split(internal_coordinates, n_redundant)):
             if all(coordinate >= 0):  # Sort out linear bends
@@ -585,9 +585,7 @@ class LocalForce:
                 self.add_internal_coordinate(atoms)
 
         # Convert coordinates to right Ångström
-        coordinates: Array2DFloat = (
-            np.array(coordinates).reshape(-1, 3) * BOHR_TO_ANGSTROM
-        )
+        coordinates = np.array(coordinates).reshape(-1, 3) * BOHR_TO_ANGSTROM
 
         # Set up attributes
         self._fc_matrix = fc_matrix
@@ -624,8 +622,8 @@ class LocalForce:
         masses: list[float] = []
         fc_matrix: Array2DFloat = np.empty([])
         ifc_matrix: Array2DFloat = np.empty([])
-        input_coordinates: list[float] = []
-        standard_coordinates: list[float] = []
+        input_coordinates = []
+        standard_coordinates = []
         n_imag: int = 0
         n_atoms: int = 0
         internal_indices: dict[frozenset[int], int] = {}
@@ -866,10 +864,8 @@ class LocalForce:
 
         # Detect whether the input coordinates have been rotated. If so, rotate
         # B matrix and its inverse.
-        input_coordinates: Array2DFloat = np.array(input_coordinates).reshape(-1, 3)
-        standard_coordinates: Array2DFloat = np.array(standard_coordinates).reshape(
-            -1, 3
-        )
+        input_coordinates = np.array(input_coordinates).reshape(-1, 3)
+        standard_coordinates = np.array(standard_coordinates).reshape(-1, 3)
 
         if (
             not np.array_equal(input_coordinates, standard_coordinates)
@@ -988,7 +984,7 @@ class LocalForce:
 
         # Convert data to right format
         coordinates = np.array(coordinates).reshape(-1, 3) * BOHR_TO_ANGSTROM
-        hessian: Array2DFloat = np.array(hessian).reshape(n_atoms * 3, n_atoms * 3)
+        hessian = np.array(hessian).reshape(n_atoms * 3, n_atoms * 3)
         normal_modes = np.array(normal_modes).reshape(-1, n_atoms * 3)[:n_modes]
         elements = convert_elements(atomic_numbers, output="numbers")
 
@@ -1071,15 +1067,15 @@ class LocalForce:
 
         # Convert quantities to right format
         n_atoms = len(masses)
-        coordinates: Array2DFloat = np.array(coordinates).reshape(-1, 3)
-        normal_modes: Array2DFloat = np.array(normal_modes).reshape(-1, n_atoms * 3)
+        coordinates = np.array(coordinates).reshape(-1, 3)
+        normal_modes = np.array(normal_modes).reshape(-1, n_atoms * 3)
         elements = convert_elements(atomic_numbers, output="numbers")
-        force_constants: Array1DFloat = np.array(force_constants)
-        frequencies: Array1DFloat = np.array(frequencies)
-        masses: Array1DFloat = np.array(masses)
+        force_constants = np.array(force_constants)
+        frequencies = np.array(frequencies)
+        masses = np.array(masses)
 
         # Detect imaginary modes
-        self.n_imag = np.sum(frequencies < 0)
+        self.n_imag = int(np.sum(frequencies < 0))
 
         # Set up attributes
         self._elements = elements
@@ -1165,10 +1161,8 @@ class LocalForce:
                 read_hessian = True
 
         # Convert data to right format
-        coordinates: Array2DFloat = (
-            np.array(coordinates).reshape(-1, 3) * BOHR_TO_ANGSTROM
-        )
-        hessian: Array2DFloat = np.array(hessian).reshape(n_atoms * 3, n_atoms * 3)
+        coordinates = np.array(coordinates).reshape(-1, 3) * BOHR_TO_ANGSTROM
+        hessian = np.array(hessian).reshape(n_atoms * 3, n_atoms * 3)
         elements = convert_elements(atomic_numbers, output="numbers")
 
         # Set up attributes

--- a/morfeus/plotting.py
+++ b/morfeus/plotting.py
@@ -7,7 +7,6 @@ import typing
 
 import numpy as np
 
-from morfeus.typing import Array1DFloat
 from morfeus.utils import Import, requires_dependency
 
 if typing.TYPE_CHECKING:
@@ -46,7 +45,7 @@ def get_drawing_arrow(
         start = [0, 0, 0]
     if direction is None:
         direction = [1, 0, 0]
-    start: Array1DFloat = np.array(start)
+    start = np.array(start)
     direction = np.array(direction) / np.linalg.norm(direction)
 
     # Create cylinder

--- a/morfeus/pyramidalization.py
+++ b/morfeus/pyramidalization.py
@@ -14,8 +14,6 @@ from morfeus.io import read_geometry
 from morfeus.typing import (
     Array1DBool,
     Array1DFloat,
-    Array1DInt,
-    Array2DFloat,
     ArrayLike1D,
     ArrayLike2D,
 )
@@ -72,7 +70,7 @@ class Pyramidalization:
         }:
             raise IndexError("Atom indices should not be 0 (1-indexed).")
 
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
         atom_coordinates = coordinates[atom_index - 1]
 
         if neighbor_indices is None:
@@ -82,13 +80,13 @@ class Pyramidalization:
 
         if excluded_atoms is None:
             excluded_atoms = []
-        excluded_atoms: Array1DBool = np.array(excluded_atoms, dtype=bool)
+        excluded_atoms = np.array(excluded_atoms, dtype=bool)
 
         # Get 3 closest neighbors
         if len(neighbor_indices) > 0:
             if len(neighbor_indices) != 3:
                 raise Exception(f"Only {len(neighbor_indices)} neighbors.")
-            neighbors: Array1DInt = np.array(neighbor_indices) - 1
+            neighbors = np.array(neighbor_indices) - 1
         elif method == "distance":
             # Generate mask for excluded atoms
             mask: Array1DBool = np.zeros(len(coordinates), dtype=bool)

--- a/morfeus/qc.py
+++ b/morfeus/qc.py
@@ -11,7 +11,6 @@ import numpy as np
 from morfeus.data import ANGSTROM_TO_BOHR, BOHR_TO_ANGSTROM
 from morfeus.typing import (
     Array1DFloat,
-    Array1DStr,
     Array2DFloat,
     Array3DFloat,
     ArrayLike2D,
@@ -99,9 +98,9 @@ def optimize_qc_engine(
         raise Exception(opt.error.error_message)
 
     # Take out results
-    energies: Array1DFloat = np.array(opt.energies)
+    energies = np.array(opt.energies)
     if return_trajectory:
-        opt_coordinates: Array2DFloat = np.array(
+        opt_coordinates = np.array(
             [result.molecule.geometry for result in opt.trajectory]
         )
     else:
@@ -227,7 +226,7 @@ def _generate_qcel_molecule(
         bos = None
 
     # Create molecule object
-    elements: Array1DStr = np.array(convert_elements(elements, output="symbols"))
+    elements = np.array(convert_elements(elements, output="symbols"))
     coordinates = np.array(coordinates) * ANGSTROM_TO_BOHR
     molecule = qcel.models.Molecule(
         symbols=elements,

--- a/morfeus/sasa.py
+++ b/morfeus/sasa.py
@@ -13,7 +13,7 @@ import scipy.spatial
 from morfeus.data import atomic_symbols, jmol_colors
 from morfeus.geometry import Atom, Sphere
 from morfeus.io import read_geometry
-from morfeus.typing import Array1DFloat, Array2DFloat, ArrayLike1D, ArrayLike2D
+from morfeus.typing import Array2DFloat, ArrayLike1D, ArrayLike2D
 from morfeus.utils import convert_elements, get_radii, Import, requires_dependency
 
 if typing.TYPE_CHECKING:
@@ -57,14 +57,14 @@ class SASA:
     ) -> None:
         # Converting elements to atomic numbers if the are symbols
         elements = convert_elements(elements, output="numbers")
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
 
         # Getting radii if they are not supplied
         if radii is None:
             radii = get_radii(elements, radii_type=radii_type)
 
         # Increment the radii with the probe radius
-        radii: Array1DFloat = np.array(radii)
+        radii = np.array(radii)
         radii = radii + probe_radius
 
         # Construct list of atoms
@@ -150,7 +150,7 @@ class SASA:
             # Select coordinates and radii for other atoms
             test_coordinates = [test_atom.coordinates for test_atom in test_atoms]
             test_radii = [test_atom.radius for test_atom in test_atoms]
-            test_radii: Array1DFloat = np.array(test_radii).reshape(-1, 1)
+            test_radii = np.array(test_radii).reshape(-1, 1)
 
             # Get distances to other atoms and subtract radii
             if test_coordinates:

--- a/morfeus/solid_angle.py
+++ b/morfeus/solid_angle.py
@@ -60,12 +60,12 @@ class SolidAngle:
 
         # Convert elements to atomic numbers if they are symbols
         elements = convert_elements(elements, output="numbers")
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
 
         # Get radii if they are not supplied
         if radii is None:
             radii = get_radii(elements, radii_type=radii_type)
-        radii: Array1DFloat = np.asarray(radii)
+        radii = np.asarray(radii)
         coordinates_metal = coordinates[metal_index - 1, :]
         coordinates -= coordinates_metal
 

--- a/morfeus/sterimol.py
+++ b/morfeus/sterimol.py
@@ -18,9 +18,7 @@ from morfeus.plotting import get_drawing_arrow
 from morfeus.sasa import SASA
 from morfeus.typing import (
     Array1DFloat,
-    Array1DInt,
     Array2DFloat,
-    Array2DInt,
     ArrayLike1D,
     ArrayLike2D,
 )
@@ -93,16 +91,16 @@ class Sterimol:
 
         # Convert elements to atomic numbers if the are symbols
         elements = convert_elements(elements, output="numbers")
-        coordinates: Array2DFloat = np.array(coordinates)
+        coordinates = np.array(coordinates)
 
         if excluded_atoms is None:
             excluded_atoms = []
-        excluded_atoms: Array2DInt = np.array(excluded_atoms)
+        excluded_atoms = np.array(excluded_atoms)
 
         # Get radii if they are not supplied
         if radii is None:
             radii = get_radii(elements, radii_type=radii_type)
-        radii: Array1DFloat = np.array(radii)
+        radii = np.array(radii)
 
         # Add dummy atom if multiple attached indices are given
         if isinstance(attached_index, Iterable):
@@ -130,7 +128,7 @@ class Sterimol:
         vector_2_to_1 = vector_2_to_1 / np.linalg.norm(vector_2_to_1)
 
         # Get rotation quaternion that overlays vector with x-axis
-        x_axis: Array1DFloat = np.array([[1.0, 0.0, 0.0]])
+        x_axis = np.array([[1.0, 0.0, 0.0]])
         R = kabsch_rotation_matrix(vector_2_to_1.reshape(1, -1), x_axis, center=False)
         all_coordinates = (R @ all_coordinates.T).T
         self._rotation_matrix = R
@@ -174,7 +172,7 @@ class Sterimol:
         Returns:
             self: Self
         """
-        points: Array2DFloat = np.array(points)
+        points = np.array(points)
         if shift is True:
             points -= self._origin
 
@@ -209,7 +207,7 @@ class Sterimol:
             coordinates: Array2DFloat = np.vstack(
                 [atom.coordinates for atom in self._atoms]
             )
-            radii: Array1DFloat = np.array([atom.radius for atom in self._atoms])
+            radii = np.array([atom.radius for atom in self._atoms])
             distances = scipy.spatial.distance.cdist(
                 self._dummy_atom.coordinates.reshape(1, -1), coordinates
             ).reshape(-1)
@@ -302,8 +300,8 @@ class Sterimol:
                 elements.append(atom.element)
                 coordinates.append(atom.coordinates)
                 radii.append(atom.radius)
-        elements: Array1DInt = np.array(elements)
-        coordinates: Array2DFloat = np.vstack(coordinates)
+        elements = np.array(elements)
+        coordinates = np.vstack(coordinates)
         radii = radii
         sasa = SASA(elements, coordinates, radii=radii, density=density, probe_radius=0)
 
@@ -333,8 +331,8 @@ class Sterimol:
                 ):
                     coordinates.append(atom.coordinates)
                     radii.append(atom.radius)
-            coordinates: Array2DFloat = np.vstack(coordinates)
-            radii: Array1DFloat = np.vstack(radii).reshape(-1)
+            coordinates = np.vstack(coordinates)
+            radii = np.vstack(radii).reshape(-1)
 
         # Project coordinates onto vector between atoms 1 and 2
         vector = self._attached_atom.coordinates - self._dummy_atom.coordinates

--- a/morfeus/utils.py
+++ b/morfeus/utils.py
@@ -26,9 +26,6 @@ from morfeus.data import (
 )
 from morfeus.typing import (
     Array1DBool,
-    Array1DFloat,
-    Array1DInt,
-    Array2DFloat,
     Array2DInt,
     ArrayLike1D,
     ArrayLike2D,
@@ -60,9 +57,9 @@ def get_excluded_from_connectivity(
         ValueError: When connected atoms belong to different fragments or when connected
             atoms belong to same fragment as other neighbors of center atoms (1-indexed)
     """
-    connectivity_matrix: Array2DInt = np.array(connectivity_matrix)
-    center_atoms: Array1DInt = np.array(center_atoms).reshape(-1) - 1
-    connected_atoms: Array1DInt = np.array(connected_atoms).reshape(-1) - 1
+    connectivity_matrix = np.array(connectivity_matrix)
+    center_atoms = np.array(center_atoms).reshape(-1) - 1
+    connected_atoms = np.array(connected_atoms).reshape(-1) - 1
     # Determine other neihgbors to the central atoms
     other_neighbors = set(
         connectivity_matrix[center_atoms].reshape(-1).nonzero()[0]
@@ -122,18 +119,16 @@ def check_distances(
     # Get radii if they are not supplied
     if radii is None:
         radii = get_radii(elements, radii_type=radii_type)
-    radii: Array1DFloat = np.array(radii)
+    radii = np.array(radii)
 
     if excluded_atoms is None:
         excluded_atoms = []
     else:
         excluded_atoms = list(excluded_atoms)
 
-    coordinates: Array2DFloat = np.array(coordinates)
-    atom_coordinates: Array2DFloat = np.array(coordinates)
-    check_coordinates: Array1DFloat = np.array(coordinates[check_atom - 1]).reshape(
-        -1, 3
-    )
+    coordinates = np.array(coordinates)
+    atom_coordinates = np.array(coordinates)
+    check_coordinates = np.array(coordinates[check_atom - 1]).reshape(-1, 3)
 
     # Calculate distances between check atom and all atoms
     distances = (
@@ -355,14 +350,14 @@ def get_connectivity_matrix(
     Raises:
         RuntimeError: When neither elements nor radii given
     """
-    coordinates: Array2DFloat = np.array(coordinates)
+    coordinates = np.array(coordinates)
     n_atoms = len(coordinates)
     if radii is None:
         if elements is None:
             raise RuntimeError("Either elements or radii needed.")
         elements = convert_elements(elements, output="numbers")
         radii = get_radii(elements, radii_type=radii_type)
-    radii: Array1DFloat = np.array(radii)
+    radii = np.array(radii)
     distance_matrix = scipy.spatial.distance_matrix(coordinates, coordinates)
     radii_matrix = np.add.outer(radii, radii) * scale_factor
     connectivity_matrix = (distance_matrix < radii_matrix) - np.identity(

--- a/morfeus/visible_volume.py
+++ b/morfeus/visible_volume.py
@@ -12,10 +12,6 @@ from morfeus.geometry import Cone
 from morfeus.io import read_geometry
 from morfeus.sasa import SASA
 from morfeus.typing import (
-    Array1DAny,
-    Array1DFloat,
-    Array1DInt,
-    Array2DFloat,
     ArrayLike1D,
     ArrayLike2D,
 )
@@ -79,11 +75,11 @@ class VisibleVolume:
         density: float = 0.01,
     ) -> None:
         # Set up arrays and get radii
-        elements: Array1DInt = np.array(convert_elements(elements, output="numbers"))
-        coordinates: Array2DFloat = np.array(coordinates)
+        elements = np.array(convert_elements(elements, output="numbers"))
+        coordinates = np.array(coordinates)
         if radii is None:
             radii = get_radii(elements, radii_type=radii_type)
-        radii: Array1DFloat = np.array(radii)
+        radii = np.array(radii)
 
         # Check so that no atom is within vdW distance of metal atom
         within = check_distances(elements, coordinates, metal_index, radii=radii)
@@ -93,9 +89,9 @@ class VisibleVolume:
 
         # Center coordinate system around metal and remove it
         coordinates -= coordinates[metal_index - 1]
-        elements: Array1DFloat = np.delete(elements, metal_index - 1)
-        coordinates: Array2DFloat = np.delete(coordinates, metal_index - 1, axis=0)
-        radii: Array1DFloat = np.delete(radii, metal_index - 1)
+        elements = np.delete(elements, metal_index - 1)
+        coordinates = np.delete(coordinates, metal_index - 1, axis=0)
+        radii = np.delete(radii, metal_index - 1)
 
         # Remove H atoms
         if include_hs is False:
@@ -121,8 +117,8 @@ class VisibleVolume:
             atom.proximal_mask = np.linalg.norm(atom.accessible_points, axis=1) < radius
 
         # Check points on other atoms against cone for each atom
-        atom_coordinates: Array2DFloat = np.array([atom.coordinates for atom in atoms])
-        atoms: Array1DAny = np.array(atoms)
+        atom_coordinates = np.array([atom.coordinates for atom in atoms])
+        atoms = np.array(atoms)
         for atom in atoms:
             # Calculate distances to other atoms
             atom.get_cone()

--- a/morfeus/xtb.py
+++ b/morfeus/xtb.py
@@ -534,8 +534,8 @@ class XTB:
                 3,
             )
         elif variety == "local_electrophilicity":
-            fukui_radical: Array1DFloat = np.array(self._results.fukui_radical)
-            fukui_dual: Array1DFloat = np.array(self._results.fukui_plus) - np.array(
+            fukui_radical = np.array(self._results.fukui_radical)
+            fukui_dual = np.array(self._results.fukui_plus) - np.array(
                 self._results.fukui_minus
             )
             chem_pot = self.get_chemical_potential(corrected=corrected)
@@ -552,9 +552,9 @@ class XTB:
                 "respectively 'minus' and 'plus'."
             )
 
-        fukui = {i: float(fukui) for i, fukui in enumerate(fukui, start=1)}
+        fukui = {i: float(f) for i, f in enumerate(fukui, start=1)}
 
-        return fukui
+        return cast("dict[int, float]", fukui)
 
     def get_global_descriptor(self, variety: str, corrected: bool = True) -> float:
         """Calculate global reactivity descriptors.


### PR DESCRIPTION
Fixes mypy errors triggered by mypy updates. Mostly:

- Removed inner type annotations. mypy now infers narrowed types from right-hand side instead, which fixes the cascade of `[operator]`/`[index]`/`[union-attr]` errors these annotations were producing
- Dropped a few list-annotations on locals that get reassigned to ndarrays mid-function
- Added `int()` wrap on np.sum result (numpy returns `numpy.bool` from sum over bool arrays)

The code now passes cleanly with mypy 2.1.0 (and numpy 2.2.6).
