### PR TITLE
Pin xtb to last working conda-forge build to solve PTB segfault

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,11 @@ jobs:
           python-version: "3.10"
       - name: Install xtb and nox
         run: |
-          conda install -y 'xtb>=6.7.1' nox
+          # xtb pinned to build 4 of 6.7.1 because build 5 is installed next to a new `multicharge`
+          # build it was not compiled against, which makes PTB calculations with xtb segfault
+          conda install -y 'xtb=6.7.1=*_4' nox
           xtb --version
+          conda list | grep -E '^(xtb|multicharge|mctc-lib) '
         shell: bash -el {0}
       - name: Run xtb tests
         run: python -m nox -s tests-3.10 -- -m xtb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-05-18
+## [Unreleased] - 2026-08-06
 
 ### Added
 - GitHub Actions job that runs xtb-marked tests on every PR (including xtb binary installation)
 - New test comparing `XTB.get_charges` output against reference xtb values
+
+### Changed
+- Pinned `xtb` to conda-forge build `6.7.1=*_4` in `environment-opt.yml` and CI `test.yml` because with newer conda-forge builds, `xtb` is installed next to a new `multicharge` build it was not compiled against, which makes PTB calculations with `xtb` segfault
+
+    TODO: once conda-forge ships a rebuilt xtb which fixes the issue, remove the patch added in PR #89.
 
 ### Fixed
 - Compatibility issue with Python 3.14 where command-line interface failed due to `fire` library's requirement for `__name__` attribute on `functools.partial` objects

--- a/environment-opt.yml
+++ b/environment-opt.yml
@@ -16,7 +16,9 @@ dependencies:
   - rdkit
   - spyrmsd
   - vtk
-  - xtb>=6.7.1
+  # xtb pinned to build 4 of 6.7.1 because build 5 is installed next to a new `multicharge`
+  # build it was not compiled against, which makes PTB calculations with xtb segfault
+  - xtb=6.7.1=*_4
   - xtb-python
   - pip:
       - pyberny


### PR DESCRIPTION
## Description

This PR is a temporary patch for the following issue:

### Problem

When installing xtb from conda-forge with the current built (version 6.7.1 built 5), running `xtb` with `--ptb` crashes with `Segmentation fault - invalid memory reference.`, therefore Morfeus' GitHub check "Testing / ubuntu / xtb / 3.10 (push)" fails (see issue https://github.com/grimme-lab/xtb/issues/1422)

### Changes

To solve this, xtb is pinned to built 4 (the latest working one) in `environment-opt.yml` and CI `test.yml`.

## To do later

Once the xTB team will have rebuild xtb-feedstock to solve this issue, remove the patch added by this PR.